### PR TITLE
feat: provide chat id in callback query context

### DIFF
--- a/src/contexts/callback-query.ts
+++ b/src/contexts/callback-query.ts
@@ -63,6 +63,13 @@ class CallbackQueryContext<Bot extends BotLike> extends Context<Bot> {
 		});
 	}
 
+	/**
+	 * Chat identifier of the message with the callback button that originated the query.
+	 */
+	get chatId() {
+		return this.message?.chat?.id;
+	}
+
 	/** Checks if the query has `queryPayload` property */
 	hasQueryPayload(): this is Require<this, "queryPayload"> {
 		return this.payload.data !== undefined;


### PR DESCRIPTION
When attempting to respond to a callback query with a message (for example, in a scene via context.send), the bot sends the message to the user via a private message rather than in the same chat.

This commit resolves this issue. The chat id is taken from the message that initiated the callback.