### PR TITLE
Fix type narrowing for `AnyBot` contexts

### DIFF
--- a/src/contexts/context.ts
+++ b/src/contexts/context.ts
@@ -4,7 +4,7 @@ import type { TelegramObjects } from "@gramio/types";
 
 import { SERVICE_MESSAGE_EVENTS } from "../utils";
 
-import type { BotLike } from "../types";
+import type { BotLike, IsAny } from "../types";
 import type { ContextType, MaybeArray, SoftString, UpdateName } from "../types";
 
 interface ContextOptions<Bot extends BotLike> {
@@ -50,11 +50,14 @@ interface Context<Bot extends BotLike> {
 	is<T extends UpdateName>(
 		rawTypes: MaybeArray<SoftString<T>>,
 	): this is ContextType<Bot, T> &
-		// biome-ignore lint/complexity/noBannedTypes: <explanation>
-		(Bot["__Derives"] extends {}
-			? Bot["__Derives"]["global"] & Bot["__Derives"][T]
-			: // biome-ignore lint/complexity/noBannedTypes: <explanation>
-				{});
+		// Check if __Derives is 'any' (from AnyBot) to prevent type collapse
+		(IsAny<Bot["__Derives"]> extends true
+			? // biome-ignore lint/complexity/noBannedTypes: empty object is needed for type guard
+				{}
+			: Bot["__Derives"] extends {}
+				? Bot["__Derives"]["global"] & Bot["__Derives"][T]
+				: // biome-ignore lint/complexity/noBannedTypes: empty object is needed for type guard
+					{});
 }
 
 inspectable(Context, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ import type {
 import type * as Contexts from "./contexts/index";
 import type * as Attachments from "./structures/attachments/index";
 
+/** Helper to detect if a type is 'any' */
+export type IsAny<T> = 0 extends (1 & T) ? true : false;
+
 interface Suppress<IsSuppressed extends boolean | undefined = undefined> {
 	/**
 	 * Pass `true` if you want to suppress throwing errors of this method.
@@ -95,7 +98,9 @@ export interface BotLike {
 export type GetDerives<
 	Bot extends BotLike,
 	Event extends keyof ContextsMapping<Bot>,
-> = Bot["__Derives"]["global"] & Bot["__Derives"][Event];
+> = IsAny<Bot["__Derives"]> extends true
+	? {}
+	: Bot["__Derives"]["global"] & Bot["__Derives"][Event];
 
 export type MessageContextWithRequiredFrom<Bot extends BotLike> = Constructor<
 	InstanceType<Contexts.MessageContext<Bot>> &


### PR DESCRIPTION
Fixes type collapse when using `ctx.is()` in `Composer` and other contexts with `AnyBot`.

### Problem

When `Bot` generic is `AnyBot`, the `__Derives` property becomes `any`, causing:
1. `GetDerives` to return `any` instead of empty intersection
2. `Context.is()` type guard to lose narrowing information

This broke type narrowing in `Composer`:
```ts
import { Composer } from "gramio";

new Composer()
  .use(async (ctx, next) => {
    if (ctx.is("message")) {
      ctx.send(""); // Error: Property 'send' does not exist
    }
  });
```

### Solution

- Add `IsAny<T>` helper type to detect `any`
- Update `GetDerives` to return `{}` when `__Derives` is `any`
- Update `Context.is()` type guard to handle `AnyBot` case

Now type narrowing works correctly while preserving derives for concrete bot types.

Closes gramiojs/gramio#26
