### PR TITLE
fix(send): auto-forward message_thread_id under Threaded Mode + callback ctx

### DIFF
--- a/src/contexts/callback-query.ts
+++ b/src/contexts/callback-query.ts
@@ -65,6 +65,17 @@ class CallbackQueryContext<Bot extends BotLike> extends Context<Bot> {
 		return this.message?.chat?.id;
 	}
 
+	/**
+	 * Identifier of the thread the originating message belongs to, or
+	 * `undefined` if it's not in a thread. Exposed so the `SendMixin`
+	 * auto-forwards `message_thread_id` on follow-up `send`/`reply`
+	 * calls from within a callback handler — keeping replies in the
+	 * same thread as the tapped button.
+	 */
+	get threadId() {
+		return this.message?.threadId;
+	}
+
 	/** Checks if the query has `queryPayload` property */
 	hasQueryPayload(): this is Require<this, "queryPayload"> {
 		return this.payload.data !== undefined;

--- a/src/contexts/mixins/send.ts
+++ b/src/contexts/mixins/send.ts
@@ -16,7 +16,6 @@ interface SendMixinMetadata {
 	get businessConnectionId(): string | undefined;
 	get senderId(): number | undefined;
 	get threadId(): number | undefined;
-	isTopicMessage: () => boolean;
 }
 
 /** This object represents a mixin which can invoke `chatId`/`senderId`-dependent methods */
@@ -28,7 +27,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendMessage({
@@ -50,7 +49,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendPhoto({
@@ -76,7 +75,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendLivePhoto({
@@ -102,7 +101,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendDocument({
@@ -124,7 +123,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendAudio({
@@ -146,7 +145,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendVideo({
@@ -171,7 +170,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendAnimation({
@@ -196,7 +195,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendVideoNote({
@@ -218,7 +217,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendVoice({
@@ -244,7 +243,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendLocation({
@@ -279,7 +278,7 @@ class SendMixin<Bot extends BotLike> {
 	async sendVenue(params: Optional<TelegramParams.SendVenueParams, "chat_id">) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendVenue({
@@ -299,7 +298,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendContact({
@@ -317,7 +316,7 @@ class SendMixin<Bot extends BotLike> {
 	async sendPoll(params: Optional<TelegramParams.SendPollParams, "chat_id">) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendPoll({
@@ -361,7 +360,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendSticker({
@@ -413,7 +412,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		return this.bot.api.sendChatAction({
@@ -430,7 +429,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendDice({
@@ -480,7 +479,7 @@ class SendMixin<Bot extends BotLike> {
 	) {
 		if (this.businessConnectionId && !params.business_connection_id)
 			params.business_connection_id = this.businessConnectionId;
-		if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
+		if (this.threadId && !params.message_thread_id)
 			params.message_thread_id = this.threadId;
 
 		const response = await this.bot.api.sendMediaGroup({
@@ -601,11 +600,7 @@ class SendMixin<Bot extends BotLike> {
 		const baseDraftParams: Record<string, unknown> = {
 			...options.draftParams,
 		};
-		if (
-			this.threadId &&
-			this.isTopicMessage?.() &&
-			!baseDraftParams.message_thread_id
-		) {
+		if (this.threadId && !baseDraftParams.message_thread_id) {
 			baseDraftParams.message_thread_id = this.threadId;
 		}
 
@@ -619,11 +614,7 @@ class SendMixin<Bot extends BotLike> {
 		) {
 			baseMessageParams.business_connection_id = this.businessConnectionId;
 		}
-		if (
-			this.threadId &&
-			this.isTopicMessage?.() &&
-			!baseMessageParams.message_thread_id
-		) {
+		if (this.threadId && !baseMessageParams.message_thread_id) {
 			baseMessageParams.message_thread_id = this.threadId;
 		}
 


### PR DESCRIPTION
## Problem

Telegram added **Threaded Mode for private chats** ([BotFather → Bot Settings → Threaded Mode](https://telegram.org/blog/threaded-conversations)), letting users hold multiple parallel conversations with a bot. Messages in those threads carry `message_thread_id` but **not** `is_topic_message` — the latter remains exclusive to forum-supergroup topics.

Two cumulative gaps in `@gramio/contexts` make replies land in the wrong thread:

### Gap 1 — `SendMixin` guards on `is_topic_message`

Every `send*` method has:

\`\`\`ts
if (this.threadId && this.isTopicMessage?.() && !params.message_thread_id)
  params.message_thread_id = this.threadId
\`\`\`

In Threaded Mode private chats, `isTopicMessage()` is `false`, so the auto-forward skips and replies fall into the chat's general thread.

### Gap 2 — `CallbackQueryContext` has no `threadId`

`CallbackQueryContext` exposes `chatId` (`this.message?.chat?.id`) so `SendMixin` can route to the right chat, but never exposed `threadId`. Inside a callback handler, `this.threadId` is `undefined` and SendMixin can't auto-forward at all — even when the original button was tapped inside a thread.

## Fix

1. **`SendMixin`**: drop the `isTopicMessage?.()` clause. `threadId` is set iff the incoming message belongs to a thread; the secondary guard was redundant for forum supergroups and harmful for Threaded Mode. Caller-override (`params.message_thread_id`) still wins.
2. **`CallbackQueryContext`**: add \`get threadId() { return this.message?.threadId }\` — symmetric with the existing `get chatId()`. Completes the `SendMixinMetadata` contract that the class already partly implemented.

`SendMixinMetadata.isTopicMessage` field is removed (no longer referenced).

## Behaviour table

| Scenario | \`threadId\` | \`isTopicMessage()\` | Before | After |
|---|---|---|---|---|
| Forum-supergroup topic message | set | true | forwards ✓ | forwards ✓ |
| Forum-supergroup General | undef | false | skips ✓ | skips ✓ |
| Top-level chat | undef | false | skips ✓ | skips ✓ |
| **Private-chat Threaded Mode** | **set** | **false** | **skips ✗** | **forwards ✓** |
| **Callback inside any thread** | **undef before / set after** | n/a | **skips ✗** | **forwards ✓** |

## Affected methods

17 send methods + sendMessageDraft's draft/message param builders.

## Validation

Tested in production against a bot with BotFather Threaded Mode enabled — `/start`, plain echoes, `/settings` menu navigation, and a streaming demo all stay in their originating thread across both forum-supergroup topics and private-chat threaded mode.